### PR TITLE
Set age group format to ##-## for better sorting.

### DIFF
--- a/inst/sql/sql_server/DemographicsAgeGroup.sql
+++ b/inst/sql/sql_server/DemographicsAgeGroup.sql
@@ -32,9 +32,9 @@ INSERT INTO #cov_ref (
 SELECT covariate_id,
 	CONCAT (
 		'age group: ',
-		CAST(5 * (covariate_id - @analysis_id) / 1000 AS VARCHAR),
+		RIGHT(CONCAT('00', CAST(5 * (covariate_id - @analysis_id) / 1000 AS VARCHAR)), 2),
 		'-',
-		CAST(1 + 5 * (covariate_id - @analysis_id) / 1000 AS VARCHAR)
+		RIGHT(CONCAT('00', CAST((5 * (covariate_id - @analysis_id) / 1000) + 4 AS VARCHAR)), 2)
 		) AS covariate_name,
 	@analysis_id AS analysis_id,
 	0 AS concept_id


### PR DESCRIPTION
Set age group format to ##-## for better sorting.
Fixed upper-bound age group label.

Note, this PR is intended to apply to the version_2 branch.