### PR TITLE
Restore -SNAPSHOT reference in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>org.ohdsi</groupId>
 	<artifactId>featureExtraction</artifactId>
 	<packaging>jar</packaging>
-	<version>2.2.4</version>
+	<version>2.2.4-SNAPSHOT</version>
 	<name>featureExtraction</name>
 	<scm>
 		<connection>scm:git:https://github.com/OHDSI/featureExtraction</connection>


### PR DESCRIPTION
Per @leeevans, I'm putting back the SNAPSHOT reference to the pom.xml so that the Jenkins build process works. Once this is merged into develop, we can confirm that the snapshot is built and merge into master. Please let me know if you have any concerns. Thanks!