### PR TITLE
Remove extraneous concept from CCI score

### DIFF
--- a/inst/sql/sql_server/CharlsonIndex.sql
+++ b/inst/sql/sql_server/CharlsonIndex.sql
@@ -244,7 +244,7 @@ INSERT INTO #charlson_concepts (
 SELECT 11,
 	descendant_concept_id
 FROM @cdm_database_schema.concept_ancestor
-WHERE ancestor_concept_id IN (4192279, 443767, 442793);
+WHERE ancestor_concept_id IN (443767, 442793);
 
 --Hemoplegia or paralegia
 INSERT INTO #charlson_scoring (


### PR DESCRIPTION
Removes the extraneous concept:

-  4192279; Medical Research Council Dyspnoea scale grade 5

From the `Diabetes with chronic complications` calculation per #108. Please let me know if there is another concept that should be used in place of this one or if we can remove it as I've proposed in this PR.