### PR TITLE
Unit tests to increase coverage in CovariateData and DetailedCovariateSettings

### DIFF
--- a/tests/testthat/test-CovariateData.R
+++ b/tests/testthat/test-CovariateData.R
@@ -1,0 +1,84 @@
+# This file covers the code in CovariateData.R. View coverage for this file using
+#library(testthat); library(FeatureExtraction)
+covr::file_report(covr::file_coverage("R/CovariateData.R", "tests/testthat/test-CovariateData.R"))
+
+
+test_that("test CovariateData Class on Empty", {
+
+  #create 4 scenarios of Covariate Data
+  #1) error (non class), 2) covariate data, 3) aggregatedCovariate Data,
+  #4) temporalCovariate Data
+
+  errCovData <- list()
+
+  covData <- FeatureExtraction:::createEmptyCovariateData(cohortId = 9999,
+                                                          aggregated = FALSE,
+                                                          temporal = FALSE)
+  aggCovData <- FeatureExtraction:::createEmptyCovariateData(cohortId = 9999,
+                                                             aggregated = TRUE,
+                                                             temporal = FALSE)
+
+  tempCovData <- FeatureExtraction:::createEmptyCovariateData(cohortId = 9999,
+                                                                aggregated = FALSE,
+                                                                temporal = TRUE)
+
+  #check that objects are covariate Data class
+  expect_false(isCovariateData(errCovData))
+  expect_true(isCovariateData(covData))
+  expect_true(isCovariateData(aggCovData))
+  expect_true(isCovariateData(tempCovData))
+
+  #check that objects are aggregate covariate data class
+  expect_error(isAggregatedCovariateData(errCovData))
+  expect_false(isAggregatedCovariateData(covData))
+  expect_true(isAggregatedCovariateData(aggCovData))
+  expect_false(isAggregatedCovariateData(tempCovData))
+
+
+  #check that objects are temporal covariate data class
+  expect_error(isTemporalCovariateData(errCovData))
+  expect_false(isTemporalCovariateData(covData))
+  expect_false(isTemporalCovariateData(aggCovData))
+  expect_true(isTemporalCovariateData(tempCovData))
+  
+  covData
+
+})
+# 
+connectionDetails <- Eunomia::getEunomiaConnectionDetails()
+Eunomia::createCohorts(connectionDetails)
+
+test_that("test saveCovariateData", {
+  saveFileTest <- tempfile("covDatSave")
+  settings <- createDefaultCovariateSettings()
+  covariateData <- getDbCovariateData(connectionDetails = connectionDetails,
+                                      cdmDatabaseSchema = "main",
+                                      cohortDatabaseSchema = "main",
+                                      cohortId = 1,
+                                      covariateSettings = settings,
+                                      aggregated = FALSE)
+  #create error for test
+  errCovData <- list()
+
+  expect_error(saveCovariateData()) #empty call error
+  expect_error(saveCovariateData(covariateData)) #no file error
+  expect_error(saveCovariateData(errCovData, file = saveFileTest)) #non covariateData class error
+  expect_message(saveCovariateData(covariateData, file = saveFileTest),
+                        "Disconnected Andromeda. This data object can no longer be used")
+  unlink(saveFileTest)
+})
+
+test_that("test summary call for covariateData class", {
+  settings <- createDefaultCovariateSettings()
+  covariateData <- getDbCovariateData(connectionDetails = connectionDetails,
+                                      cdmDatabaseSchema = "main",
+                                      cohortDatabaseSchema = "main",
+                                      cohortId = 1,
+                                      covariateSettings = settings,
+                                      aggregated = FALSE)
+  
+  sumOut <- summary(covariateData)
+  
+  expect_equal(sumOut$metaData$cohortId, 1L)
+})
+

--- a/tests/testthat/test-CovariateData.R
+++ b/tests/testthat/test-CovariateData.R
@@ -1,6 +1,5 @@
 # This file covers the code in CovariateData.R. View coverage for this file using
 #library(testthat); library(FeatureExtraction)
-covr::file_report(covr::file_coverage("R/CovariateData.R", "tests/testthat/test-CovariateData.R"))
 
 
 test_that("test CovariateData Class on Empty", {
@@ -40,11 +39,12 @@ test_that("test CovariateData Class on Empty", {
   expect_false(isTemporalCovariateData(covData))
   expect_false(isTemporalCovariateData(aggCovData))
   expect_true(isTemporalCovariateData(tempCovData))
-  
-  covData
 
+  Andromeda::close(covData)
+  Andromeda::close(aggCovData)
+  Andromeda::close(tempCovData)
 })
-# 
+
 connectionDetails <- Eunomia::getEunomiaConnectionDetails()
 Eunomia::createCohorts(connectionDetails)
 
@@ -65,6 +65,7 @@ test_that("test saveCovariateData", {
   expect_error(saveCovariateData(errCovData, file = saveFileTest)) #non covariateData class error
   expect_message(saveCovariateData(covariateData, file = saveFileTest),
                         "Disconnected Andromeda. This data object can no longer be used")
+  Andromeda::close(covariateData)
   unlink(saveFileTest)
 })
 
@@ -76,9 +77,15 @@ test_that("test summary call for covariateData class", {
                                       cohortId = 1,
                                       covariateSettings = settings,
                                       aggregated = FALSE)
-  
+
   sumOut <- summary(covariateData)
-  
+  Andromeda::close(covariateData)
   expect_equal(sumOut$metaData$cohortId, 1L)
 })
 
+
+test_that("test loadCovariateData", {
+  covDatLoadTest <- loadCovariateData("resources/continuousCovariateData.zip")
+  expect_s4_class(covDatLoadTest, "CovariateData")
+  expect_error(loadCovariateData("errorPath"))
+})

--- a/tests/testthat/test-DetailedCovariateSettings.R
+++ b/tests/testthat/test-DetailedCovariateSettings.R
@@ -1,0 +1,49 @@
+# This file covers the code in DetailedCovariateData.R. View coverage for this file using
+#library(testthat); library(FeatureExtraction)
+#covr::file_report(covr::file_coverage("R/DetailedCovariateSettings.R", "tests/testthat/test-DetailedCovariateSettings.R"))
+
+test_that("test createDetailedCovariateSettings", {
+  analysisDetails <- createAnalysisDetails(analysisId = 1,
+                                           sqlFileName = "DemographicsGender.sql",
+                                           parameters = list(analysisId = 1,
+                                                             analysisName = "Gender",
+                                                             domainId = "Demographics"),
+                                           includedCovariateConceptIds = c(),
+                                           addDescendantsToInclude = FALSE,
+                                           excludedCovariateConceptIds = c(),
+                                           addDescendantsToExclude = FALSE,
+                                           includedCovariateIds = c())
+  
+  settings <- createDetailedCovariateSettings(list(analysisDetails))
+  temporalSettings <- createDetailedTemporalCovariateSettings(list(analysisDetails))
+  expect_s3_class(settings, "covariateSettings")
+  expect_s3_class(temporalSettings, "covariateSettings")
+  expect_equal(temporalSettings$temporalStartDays, -365:-1)
+})
+
+test_that("test createDetailedTemporalCovariateSettings",{
+  analysisDetails <- createAnalysisDetails(analysisId = 1,
+                                           sqlFileName = "DemographicsGender.sql",
+                                           parameters = list(analysisId = 1,
+                                                             analysisName = "Gender",
+                                                             domainId = "Demographics"),
+                                           includedCovariateConceptIds = c(),
+                                           addDescendantsToInclude = FALSE,
+                                           excludedCovariateConceptIds = c(),
+                                           addDescendantsToExclude = FALSE,
+                                           includedCovariateIds = c())
+  
+  temporalSettings <- createDetailedTemporalCovariateSettings(list(analysisDetails))
+  expect_s3_class(temporalSettings, "covariateSettings")
+  expect_equal(temporalSettings$temporalStartDays, -365:-1)
+  
+})
+
+
+test_that("test convertPrespecSettingsToDetailedSettings", {
+  settings <- createCovariateSettings(useDemographicsAgeGroup = TRUE, useChads2Vasc = TRUE)
+  convertedSettings <- convertPrespecSettingsToDetailedSettings(settings)
+  expect_s3_class(convertedSettings, "covariateSettings")
+  expect_equal(names(convertedSettings), c("temporal", "analyses"))
+  expect_equal(convertedSettings$analyses[[1]]$sqlFileName, "DemographicsAgeGroup.sql")
+})

--- a/tests/testthat/test-DetailedCovariateSettings.R
+++ b/tests/testthat/test-DetailedCovariateSettings.R
@@ -1,6 +1,6 @@
 # This file covers the code in DetailedCovariateData.R. View coverage for this file using
-#library(testthat); library(FeatureExtraction)
-#covr::file_report(covr::file_coverage("R/DetailedCovariateSettings.R", "tests/testthat/test-DetailedCovariateSettings.R"))
+library(testthat); library(FeatureExtraction)
+
 
 test_that("test createDetailedCovariateSettings", {
   analysisDetails <- createAnalysisDetails(analysisId = 1,
@@ -46,4 +46,14 @@ test_that("test convertPrespecSettingsToDetailedSettings", {
   expect_s3_class(convertedSettings, "covariateSettings")
   expect_equal(names(convertedSettings), c("temporal", "analyses"))
   expect_equal(convertedSettings$analyses[[1]]$sqlFileName, "DemographicsAgeGroup.sql")
+})
+
+test_that("test createDefaultCovariateSettings", {
+  settings <- createDefaultCovariateSettings()
+  expect_s3_class(settings, "covariateSettings")
+})
+
+test_that("test createDefaultTemporalCovariateSettings", {
+  settings <- createDefaultTemporalCovariateSettings()
+  expect_s3_class(settings, "covariateSettings")
 })


### PR DESCRIPTION
Adding unit test to increase coverage in Covariate Data and DetailedCovariate Settings
- test to check save and load covariate data
- -tests to check various cases of covariate data using empty as example
- test different versions of detailed covariate settings 
