### PR TITLE
remove unused variables in setup.R

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -136,8 +136,6 @@ if (runTestsOnEunomia) {
   eunomiaConnectionDetails <- Eunomia::getEunomiaConnectionDetails(databaseFile = "testEunomia.sqlite")
   eunomiaCdmDatabaseSchema <- "main"
   eunomiaOhdsiDatabaseSchema <- "main"
-  eunomiaCohortAttributeTable <- "cohort_attribute"
-  eunomiaAttributeDefinitionTable <- "attribute_definition"
   eunomiaConnection <- createUnitTestData(eunomiaConnectionDetails, eunomiaCdmDatabaseSchema, eunomiaOhdsiDatabaseSchema, cohortTable, cohortAttributeTable, attributeDefinitionTable)
   Eunomia::createCohorts(connectionDetails = eunomiaConnectionDetails,
                          cdmDatabaseSchema = eunomiaCdmDatabaseSchema,


### PR DESCRIPTION
I noticed that some variables in the setup.R, related to setting up eunomia test data, are not actually used. This has recently been modified to fix #178 

