### PR TITLE
aggregate metadata items in single list

### DIFF
--- a/R/GetCovariates.R
+++ b/R/GetCovariates.R
@@ -186,7 +186,7 @@ getDbCovariateData <- function(connectionDetails = NULL,
           Andromeda::appendToTable(covariateData$covariateRef, tempCovariateData$covariateRef)
           Andromeda::appendToTable(covariateData$analysisRef, tempCovariateData$analysisRef)
           for (name in names(attr(tempCovariateData, "metaData"))) {
-            if (is.null(attr(covariateData, "metaData")[name])) {
+            if (is.null(attr(covariateData, "metaData")[[name]])) {
               attr(covariateData, "metaData")[[name]] <- attr(tempCovariateData, "metaData")[[name]]
             } else {
               attr(covariateData, "metaData")[[name]] <- list(

--- a/R/GetCovariates.R
+++ b/R/GetCovariates.R
@@ -190,8 +190,8 @@ getDbCovariateData <- function(connectionDetails = NULL,
               attr(covariateData, "metaData")[[name]] <- attr(tempCovariateData, "metaData")[[name]]
             } else {
               attr(covariateData, "metaData")[[name]] <- list(
-                attr(covariateData, "metaData")[[name]],
-                attr(tempCovariateData, "metaData")[[name]]
+                c(unlist(attr(covariateData, "metaData")[[name]]),
+                  attr(tempCovariateData, "metaData")[[name]])
               )
             }
           }

--- a/tests/testthat/test-CovariateData.R
+++ b/tests/testthat/test-CovariateData.R
@@ -109,6 +109,7 @@ test_that("Test show method", {
   expect_invisible(show(cvData))
   on.exit(rm(cvData))
 })
+
 test_that("getDbCovariateData cohortId warning", {
   skip_if_not(dbms == "sqlite")
   settings <- createDefaultCovariateSettings()
@@ -120,3 +121,18 @@ test_that("getDbCovariateData cohortId warning", {
                      aggregated = FALSE), "cohortId argument has been deprecated, please use cohortIds")
 })
 
+test_that("getDbCovariateData settings list - check metaData", {
+  skip_if_not(dbms == "sqlite")
+  looCovSet <- FeatureExtraction:::.createLooCovariateSettings(useLengthOfObs = TRUE)
+  covariateSettingsList <- list(looCovSet, looCovSet)
+  covariateData <- getDbCovariateData(connection = eunomiaConnection,
+                                      cdmDatabaseSchema = eunomiaCdmDatabaseSchema,
+                                      cohortTable = "cohort",
+                                      cohortIds = c(-1),
+                                      covariateSettings = covariateSettingsList)
+  metaData <- attr(covariateData, "metaData")
+  expect_true("sql" %in% names(metaData))
+  expect_equal(class(metaData$sql), "list") 
+  expect_equal(length(metaData$sql), 1)
+  expect_equal(length(metaData$sql[[1]]), 2)
+})


### PR DESCRIPTION
see #195 
right now, the metadata items are stored in a list per covariate. This change is putting them in a single list.