### PR TITLE
minCharacterizationMean inclusive of min value and add upper bound constraint

### DIFF
--- a/R/GetCovariates.R
+++ b/R/GetCovariates.R
@@ -121,7 +121,7 @@ getDbCovariateData <- function(connectionDetails = NULL,
   }
   errorMessages <- checkmate::makeAssertCollection()
   minCharacterizationMean <- utils::type.convert(minCharacterizationMean, as.is = TRUE)
-  checkmate::assertNumeric(x = minCharacterizationMean, lower = 0, add = errorMessages)
+  checkmate::assertNumeric(x = minCharacterizationMean, lower = 0, upper = 1, add = errorMessages)
   checkmate::reportAssertions(collection = errorMessages)
   if (!is.null(connectionDetails)) {
     connection <- DatabaseConnector::connect(connectionDetails)

--- a/R/GetCovariatesFromOtherCohorts.R
+++ b/R/GetCovariatesFromOtherCohorts.R
@@ -22,7 +22,7 @@
 #' @param covariateSettings   An object of type \code{covariateSettings} as created using the
 #'                            \code{\link{createCohortBasedCovariateSettings}} or
 #'                            \code{\link{createCohortBasedTemporalCovariateSettings}} functions.
-#' @param minCharacterizationMean The minimum mean value for characterization output. Values below this will be cut off from output. This 
+#' @param minCharacterizationMean The minimum mean value for binary characterization output. Values below this will be cut off from output. This 
 #'                                will help reduce the file size of the characterization output, but will remove information
 #'                                on covariates that have very low values. The default is 0.
 #' @template GetCovarParams

--- a/R/GetCovariatesFromOtherCohorts.R
+++ b/R/GetCovariatesFromOtherCohorts.R
@@ -50,7 +50,7 @@ getDbCohortBasedCovariatesData <- function(connection,
   checkmate::assertClass(covariateSettings, "covariateSettings", add = errorMessages)
   checkmate::assertLogical(aggregated, len = 1, add = errorMessages)
   minCharacterizationMean <- utils::type.convert(minCharacterizationMean, as.is = TRUE)
-  checkmate::assertNumeric(x = minCharacterizationMean, lower = 0, add = errorMessages)
+  checkmate::assertNumeric(x = minCharacterizationMean, lower = 0, upper = 1, add = errorMessages)
   checkmate::reportAssertions(collection = errorMessages)
   if (!missing(cohortId)) { 
     warning("cohortId argument has been deprecated, please use cohortIds")

--- a/R/GetDefaultCovariates.R
+++ b/R/GetDefaultCovariates.R
@@ -31,7 +31,7 @@
 #'                               it is a temp table, do not specify \code{targetDatabaseSchema}.
 #' @param targetCovariateRefTable (Optional) The name of the table where the covariate reference will be stored.
 #' @param targetAnalysisRefTable (Optional) The name of the table where the analysis reference will be stored.
-#' @param minCharacterizationMean The minimum mean value for characterization output. Values below this will be cut off from output. This 
+#' @param minCharacterizationMean The minimum mean value for binary characterization output. Values below this will be cut off from output. This 
 #'                                will help reduce the file size of the characterization output, but will remove information
 #'                                on covariates that have very low values. The default is 0.
 #'
@@ -152,7 +152,6 @@ getDbDefaultCovariateData <- function(connection,
         andromedaTableName = "covariatesContinuous",
         snakeCaseToCamelCase = TRUE
       )
-      filterCovariateDataCovariates(covariateData, "covariatesContinuous", minCharacterizationMean)
     }
 
     # Covariate reference

--- a/R/GetDefaultCovariates.R
+++ b/R/GetDefaultCovariates.R
@@ -85,7 +85,7 @@ getDbDefaultCovariateData <- function(connection,
   }
   errorMessages <- checkmate::makeAssertCollection()
   minCharacterizationMean <- utils::type.convert(minCharacterizationMean, as.is = TRUE)
-  checkmate::assertNumeric(x = minCharacterizationMean, lower = 0, add = errorMessages)
+  checkmate::assertNumeric(x = minCharacterizationMean, lower = 0, upper = 1, add = errorMessages)
   checkmate::reportAssertions(collection = errorMessages)
   
   settings <- .toJson(covariateSettings)
@@ -295,6 +295,6 @@ getDbDefaultCovariateData <- function(connection,
 filterCovariateDataCovariates <- function(covariateData, covariatesName, minCharacterizationMean = 0) {
   if ("averageValue" %in% colnames(covariateData[[covariatesName]]) && minCharacterizationMean != 0) {
     covariateData[[covariatesName]] <- covariateData[[covariatesName]] %>%
-      dplyr::filter(.data$averageValue > minCharacterizationMean)
+      dplyr::filter(.data$averageValue >= minCharacterizationMean)
   }
 }

--- a/R/UnitTestHelperFunctions.R
+++ b/R/UnitTestHelperFunctions.R
@@ -59,7 +59,7 @@
 #'                               of the createCovariate functions, or a list of such objects.
 #' @param aggregated             Should aggregate statistics be computed instead of covariates per
 #'                               cohort entry?
-#' @param minCharacterizationMean The minimum mean value for characterization output. Values below this will be cut off from output. This 
+#' @param minCharacterizationMean The minimum mean value for binary characterization output. Values below this will be cut off from output. This 
 #'                                will help reduce the file size of the characterization output, but will remove information
 #'                                on covariates that have very low values. The default is 0.
 #' @return

--- a/tests/testthat/test-CovariateData.R
+++ b/tests/testthat/test-CovariateData.R
@@ -97,10 +97,7 @@ test_that("test filtering of covariates based on minCharacterizationMean", {
   nCovariates <- covariateData$covariates %>% 
     collect() %>%
     nrow()
-  nCovariatesCont <- covariateData$covariatesContinuous %>% 
-    collect() %>%
-    nrow()
-  
+
   covariateData <- getDbCovariateData(connectionDetails = eunomiaConnectionDetails,
                                       cdmDatabaseSchema = eunomiaCdmDatabaseSchema,
                                       cohortDatabaseSchema = eunomiaOhdsiDatabaseSchema,
@@ -111,11 +108,7 @@ test_that("test filtering of covariates based on minCharacterizationMean", {
   nCovariatesFiltered <- covariateData$covariates %>% 
     collect() %>%
     nrow()
-  nCovariatesContFiltered <- covariateData$covariatesContinuous %>% 
-    collect() %>%
-    nrow()
   expect_true(nCovariatesFiltered < nCovariates)
-  expect_true(nCovariatesContFiltered < nCovariatesCont)
 })
 
 test_that("test loadCovariateData", {


### PR DESCRIPTION
Aims to fix #249. Some additional notes: I removed the data filtering for continuous covariates as this is not desired. We only want to limit the output for binary covariates as those are the ones that have the large output. As a result, I added an upper-bound constraint to the `minCharacterizationMean` parameter to ensure it is between 0 and 1, inclusive.

